### PR TITLE
ログインをクッキーで永続化できるようにする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,9 @@ class ApplicationController < ActionController::Base
   def current_user
     if session[:user_id]
       @current_user ||= User.find(session[:user_id])
+    elsif user_id = cookies.signed[:user_id]
+      user = User.find_by(id: user_id)
+      @current_user = user if user&.authenticated?(cookies[:remember_token])
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 class SessionsController < ApplicationController
   before_action :redirect_if_already_logged_in, only: [:new, :create]
-  
+
   def create
     user = User.find_by(email: params[:email])
 
@@ -10,11 +10,27 @@ class SessionsController < ApplicationController
     end
 
     session[:user_id] = user.id
+    params[:remember_me] == '1' ? set_cookie(user) : delete_cookie(user)
     redirect_to salons_path, success: "ログインしました"
   end
 
   def destroy
+    delete_cookie(current_user)
     session.delete(:user_id)
     redirect_to salons_path, success: "ログアウトしました"
+  end
+
+  private
+
+  def set_cookie(user)
+    user.set_remember_digest
+    cookies.permanent.signed[:user_id] = user.id
+    cookies.permanent[:remember_token] = user.remember_token
+  end
+
+  def delete_cookie(user)
+    user.delete_remember_digest
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,6 @@ class User < ApplicationRecord
 
   enum role: { normal: 0, admin: 1, }
 
-  delegate :set_cookie, :delete_cookie, to: :session
-
   #仮想のremember_token属性を定義
   attr_accessor :remember_token
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,20 +14,10 @@ class User < ApplicationRecord
   #仮想のremember_token属性を定義
   attr_accessor :remember_token
 
-  #渡されたトークンのハッシュ値を返す(rails tutorialの分岐は現在テストで使用してないので省く)
-  def self.hash_value(token)
-    BCrypt::Password.create(token)
-  end
-
-  #ランダムなトークンを返す
-  def self.random_token
-    SecureRandom.urlsafe_base64
-  end
-
   #ハッシュ化したトークンをremember_digestに入れる
   def set_remember_digest
-    self.remember_token = User.random_token
-    update_attribute(:remember_digest, User.hash_value(remember_token))
+    self.remember_token = SecureRandom.urlsafe_base64
+    update_attribute(:remember_digest, BCrypt::Password.create(remember_token))
   end
 
   #is_password(token)で渡されたトークンとユーザーのもつremember_digestを認証

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,9 @@ class User < ApplicationRecord
 
   #ランダムに生成したトークンをremember_tokenに入れて、そこからハッシュ化してremember_digestをアップデート
   def set_remember_digest
+    #SecureRandom.urlsafe_base64 => ランダムなトークンを生成
     self.remember_token = SecureRandom.urlsafe_base64
+    #BCrypt::Password.create(引数) => 引数の文字列をハッシュ化
     update_attribute(:remember_digest, BCrypt::Password.create(remember_token))
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   #仮想のremember_token属性を定義
   attr_accessor :remember_token
 
-  #ハッシュ化したトークンをremember_digestに入れる
+  #ランダムに生成したトークンをremember_tokenに入れて、そこからハッシュ化してremember_digestをアップデート
   def set_remember_digest
     self.remember_token = SecureRandom.urlsafe_base64
     update_attribute(:remember_digest, BCrypt::Password.create(remember_token))

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,7 +9,7 @@
       <input name="password" type="password" placeholder="パスワード">
       <%= f.label :remember_me, class: "checkbox inline" do %>
         <%= f.check_box :remember_me %>
-        <span>Remember me on this computer</span>
+        <span>ログインを維持する</span>
       <% end %>
     </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,12 +1,16 @@
 <h1>ログインページ</h1>
 
 <div>
-  <%= form_with url: sessions_path, method: :post, local: true do %>
+  <%= form_with url: sessions_path, method: :post, local: true do |f| %>
     <div>
       <label>メールアドレス</label>
       <input name="email" type="text" placeholder="メールアドレス">
       <label>パスワード</label>
       <input name="password" type="password" placeholder="パスワード">
+      <%= f.label :remember_me, class: "checkbox inline" do %>
+        <%= f.check_box :remember_me %>
+        <span>Remember me on this computer</span>
+      <% end %>
     </div>
 
     <div">

--- a/db/migrate/20201130035720_add_remember_digest_to_users.rb
+++ b/db/migrate/20201130035720_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :remember_digest, :string, after: :password_digest
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_013839) do
+ActiveRecord::Schema.define(version: 2020_11_30_035720) do
 
   create_table "reviews", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "comment"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2020_11_30_013839) do
     t.string "name"
     t.string "email"
     t.string "password_digest"
+    t.string "remember_digest"
     t.integer "role", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
> 参考 
>
>↓大筋はrails tutorial session管理の仕様が違うのでそこを合わせて改変、自分なりにリファクタリングとメソッド名をわかりやすくした
https://railstutorial.jp/chapters/advanced_login?version=6.0#cha-advanced_login
>
>↓ActiveModel::SecurePassword.min_costを調べてとりあえず必要ないと判断
>https://qiita.com/shinya_ichinoseki/items/cedde49adc1d1e886195